### PR TITLE
Upgrade 14

### DIFF
--- a/Classes/Controller/FormResultsController.php
+++ b/Classes/Controller/FormResultsController.php
@@ -61,11 +61,12 @@ use TYPO3\CMS\Form\Domain\Exception\RenderingException;
 use TYPO3\CMS\Form\Domain\Exception\TypeDefinitionNotFoundException;
 use TYPO3\CMS\Form\Domain\Exception\TypeDefinitionNotValidException;
 use TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory;
+use TYPO3\CMS\Form\Domain\DTO\SearchCriteria;
 use TYPO3\CMS\Form\Domain\Model\FormDefinition;
 use TYPO3\CMS\Form\Domain\Model\FormElements\AbstractFormElement;
-use TYPO3\CMS\Form\Enum\SortDirection;
 use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManagerInterface;
 use TYPO3\CMS\Form\Slot\FilePersistenceSlot;
+use TYPO3\CMS\Form\Storage\FileMountStorageAdapter;
 
 /**
  * Class FormResultsController
@@ -95,6 +96,8 @@ class FormResultsController extends FormManagerController
 
     protected ModuleTemplate $moduleTemplate;
 
+    protected FileMountStorageAdapter $fileMountStorageAdapter;
+
     /**
      * Injects the FormResultRepository
      */
@@ -109,6 +112,14 @@ class FormResultsController extends FormManagerController
     public function injectFormResultDatabaseService(FormResultDatabaseService $formResultDatabaseService): void
     {
         $this->formResultDatabaseService = $formResultDatabaseService;
+    }
+
+    /**
+     * Injects the FileMountStorageAdapter
+     */
+    public function injectFileMountStorageAdapter(FileMountStorageAdapter $fileMountStorageAdapter): void
+    {
+        $this->fileMountStorageAdapter = $fileMountStorageAdapter;
     }
 
     /**
@@ -133,16 +144,16 @@ class FormResultsController extends FormManagerController
      * @throws Exception
      * @internal
      */
-    public function indexAction(int $page = 1, string $searchTerm = '', string $orderField = '', ?SortDirection $orderDirection = null): ResponseInterface
+    public function indexAction(int $page = 1, string $searchTerm = '', string $orderField = '', ?string $orderDirection = null): ResponseInterface
     {
         $this->moduleTemplate = $this->moduleTemplateFactory->create($this->request);
 
         $availableFormDefinitions = [];
         $searchKey = ((array)$this->request->getParsedBody())['tx_form_to_database']['search'] ?? '';
         if (empty($searchKey)) {
-            $availableFormDefinitions = $this->getAvailableFormDefinitions($this->getFormSettings());
+            $availableFormDefinitions = $this->getAvailableFormDefinitions($this->getFormSettings(), new SearchCriteria());
         } else {
-            foreach ($this->getAvailableFormDefinitions($this->getFormSettings()) as $formDefinition) {
+            foreach ($this->getAvailableFormDefinitions($this->getFormSettings(), new SearchCriteria()) as $formDefinition) {
                 $searchField = 'name';
                 if (
                     is_string($formDefinition[$searchField])
@@ -479,20 +490,19 @@ class FormResultsController extends FormManagerController
      *     identifier: string
      * }>
      */
-    protected function getAvailableFormDefinitions(array $formSettings, string $searchTerm = '', string $orderField = '', ?SortDirection $orderDirection = null): array
+    protected function getAvailableFormDefinitions(array $formSettings, SearchCriteria $searchCriteria = new SearchCriteria(), string $returnUrl = ''): array
     {
         $formResults = $this->formResultDatabaseService->getAllFormResultsForPersistenceIdentifier();
         $availableFormDefinitions = [];
-        foreach ($this->formPersistenceManager->listForms($formSettings) as $formDefinition) {
-            $form = $this->formPersistenceManager->load(
-                $formDefinition['persistenceIdentifier'],
-                $formSettings,
-                /**
-                 * Empty array in BE usages
-                 * @see FormPersistenceManagerInterface::load()
-                 */
-                []
-            );
+        foreach ($this->formPersistenceManager->listForms($formSettings, $searchCriteria) as $formMetadata) {
+            // listForms() returns FormMetadata DTOs since TYPO3 v14 - keep the
+            // array shape used by the templates and the enrichment methods
+            $formDefinition = [
+                'identifier' => $formMetadata->identifier,
+                'name' => $formMetadata->name,
+                'persistenceIdentifier' => $formMetadata->persistenceIdentifier,
+            ];
+            $form = $this->formPersistenceManager->load($formDefinition['persistenceIdentifier']);
             $finisherInVariant = false;
             if (isset($form['variants'])) {
                 foreach ($form['variants'] as $variant) {
@@ -536,7 +546,7 @@ class FormResultsController extends FormManagerController
     protected function getDeletedFormDefinitions(array $availableFormDefinitions): array
     {
         $accessibleDeletedFormDefinitions = [];
-        $storageFolders = $this->formPersistenceManager->getAccessibleFormStorageFolders($this->getFormSettings());
+        $storageFolders = $this->fileMountStorageAdapter->getAccessibleFormStorageFolders();
         /** @var FileExtensionFilter $filter */
         $filter = GeneralUtility::makeInstance(FileExtensionFilter::class);
         $filter->setAllowedFileExtensions(['deleted']);
@@ -618,11 +628,7 @@ class FormResultsController extends FormManagerController
         string $formPersistenceIdentifier,
         bool $useFieldStateDataAsRenderables = false
     ): array {
-        $configuration = $this->formPersistenceManager->load(
-            $formPersistenceIdentifier,
-            $this->getFormSettings(),
-            []
-        );
+        $configuration = $this->formPersistenceManager->load($formPersistenceIdentifier);
 
         $this->hydrateRepeatableFields($configuration);
         $this->enrichFieldStateWithListViewStates($configuration);

--- a/Classes/Controller/FormResultsController.php
+++ b/Classes/Controller/FormResultsController.php
@@ -456,20 +456,26 @@ class FormResultsController extends FormManagerController
         ));
     }
 
-    public function updateItemListSelectAction(): RedirectResponse
+    /**
+     * @param string $formPersistenceIdentifier
+     * @param array<string, string> $field Selected columns; empty when all columns are deselected
+     */
+    public function updateItemListSelectAction(string $formPersistenceIdentifier = '', array $field = []): RedirectResponse
     {
-        $formPersistenceIdentifier = $this->request->getArgument('formPersistenceIdentifier');
+        if ($formPersistenceIdentifier === '') {
+            return new RedirectResponse($this->uriBuilder->uriFor('index'));
+        }
         $formDefinition = $this->getFormDefinition($formPersistenceIdentifier);
         /** @var FormDefinitionUtility $formDefinitionUtility */
         $formDefinitionUtility = GeneralUtility::makeInstance(FormDefinitionUtility::class);
         $formDefinitionUtility->addFieldStateIfDoesNotExist($formDefinition);
 
-        $this->BEUser->uc['tx_formtodatabase']['listViewStates'][$formDefinition['identifier']] = $this->request->getArgument('field');
+        $this->BEUser->uc['tx_formtodatabase']['listViewStates'][$formDefinition['identifier']] = $field;
         $this->BEUser->writeUC();
 
         return new RedirectResponse($this->uriBuilder->uriFor(
             'show',
-            ['formPersistenceIdentifier' => $this->request->getArgument('formPersistenceIdentifier')]
+            ['formPersistenceIdentifier' => $formPersistenceIdentifier]
         ));
     }
 
@@ -1119,30 +1125,14 @@ class FormResultsController extends FormManagerController
             $buttonBar->addButton($backFormButton, ButtonBar::BUTTON_POSITION_LEFT);
         }
 
-        // Reload title
-        $reloadTitle = $this->getLanguageService()->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.reload');
-        $reloadButton = $buttonBar->makeLinkButton()
-            ->setHref(GeneralUtility::getIndpEnv('REQUEST_URI'))
-            ->setTitle($reloadTitle)
-            ->setIcon($this->iconFactory->getIcon('actions-refresh', IconSize::SMALL));
-        $buttonBar->addButton($reloadButton, ButtonBar::BUTTON_POSITION_RIGHT);
-
-        // Shortcut
-        $mayMakeShortcut = $this->getBackendUser()->mayMakeShortcut();
-        if ($mayMakeShortcut) {
-            $extensionName = $currentRequest->getControllerExtensionName();
-            if (count($getVars) === 0) {
-                $modulePrefix = strtolower('tx_' . $extensionName . '_' . $moduleName);
-                $getVars = ['id', 'route', $modulePrefix];
-            }
-
-            $shortcutButton = $buttonBar
-                ->makeShortcutButton()
-                ->setRouteIdentifier($moduleName)
-                ->setDisplayName($this->getLanguageService()->sL('LLL:EXT:form/Resources/Private/Language/Database.xlf:module.shortcut_name'))
-                ->setArguments($getVars);
-            $buttonBar->addButton($shortcutButton, ButtonBar::BUTTON_POSITION_RIGHT);
-        }
+        // Since TYPO3 v14 the reload button is added to all modules automatically.
+        // The shortcut button is provided via the shortcut context (manual
+        // ShortcutButton creation is deprecated since v14).
+        $this->moduleTemplate->getDocHeaderComponent()->setShortcutContext(
+            $moduleName,
+            $this->getLanguageService()->sL('LLL:EXT:form/Resources/Private/Language/Database.xlf:module.shortcut_name'),
+            $getVars
+        );
     }
 
     /**

--- a/Classes/Controller/FormResultsController.php
+++ b/Classes/Controller/FormResultsController.php
@@ -206,8 +206,8 @@ class FormResultsController extends FormManagerController
             'stylesheet',
             'print'
         );
-        // @todo check for correct implementation
         $this->pageRenderer->loadJavaScriptModule('@typo3/backend/modal.js');
+        $this->pageRenderer->loadJavaScriptModule('@liquidlight/form-to-database/column-selector.js');
         $this->pageRenderer->addInlineLanguageLabelArray([
             'ftd_deleteTitle' => $this->getLanguageService()->sL($languageFile . 'show.buttons.delete.title'),
             'ftd_deleteDescription' => $this->getLanguageService()->sL($languageFile . 'show.buttons.delete.description'),

--- a/Classes/Hooks/FormHooks.php
+++ b/Classes/Hooks/FormHooks.php
@@ -14,17 +14,24 @@ namespace LiquidLight\FormToDatabase\Hooks;
 use LiquidLight\FormToDatabase\Domain\Model\FormResult;
 use LiquidLight\FormToDatabase\Domain\Repository\FormResultRepository;
 use LiquidLight\FormToDatabase\Utility\UniqueFieldHandler;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
 use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
+use TYPO3\CMS\Form\Event\BeforeFormIsDeletedEvent;
+use TYPO3\CMS\Form\Event\BeforeFormIsSavedEvent;
 use TYPO3\CMS\Form\Mvc\Persistence\Exception\PersistenceManagerException;
 use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManager;
 
 /**
  * Class FormHooks
+ *
+ * Since TYPO3 v14 the former SC_OPTIONS ext/form hooks (beforeFormSave,
+ * beforeFormDelete) are replaced by the PSR-14 events
+ * BeforeFormIsSavedEvent / BeforeFormIsDeletedEvent.
  *
  * todo: split hooks into separate files and load only necessary dependencies
  */
@@ -43,16 +50,15 @@ final class FormHooks
      * @throws InvalidQueryException
      * @throws PersistenceManagerException
      */
-    public function beforeFormDelete(string $formPersistenceIdentifier): void
+    #[AsEventListener('form-to-database/before-form-is-deleted')]
+    public function beforeFormDelete(BeforeFormIsDeletedEvent $event): void
     {
+        $formPersistenceIdentifier = $event->formPersistenceIdentifier;
+
         // empty form settings correct here, as an empty array will allow all
         // entry points. This is, what is better at this point
         $formSettings = [];
-        $yaml = $this->formPersistenceManager->load(
-            $formPersistenceIdentifier,
-            $formSettings,
-            []
-        );
+        $yaml = $this->formPersistenceManager->load($formPersistenceIdentifier);
 
         /** @var File $file */
         $file = $this->resourceFactory->getFileObjectFromCombinedIdentifier($formPersistenceIdentifier);
@@ -84,11 +90,10 @@ final class FormHooks
 
     /**
      * Keep track of field identifiers of deleted and new fields, so that identifiers are not reused
-     *
-     * @param array<array-key, mixed> $formDefinition
      */
-    public function beforeFormSave(string $formPersistenceIdentifier, array $formDefinition): mixed
+    #[AsEventListener('form-to-database/before-form-is-saved')]
+    public function beforeFormSave(BeforeFormIsSavedEvent $event): void
     {
-        return $this->uniqueFieldHandler->updateNewFields($formPersistenceIdentifier, $formDefinition);
+        $event->form = $this->uniqueFieldHandler->updateNewFields($event->formPersistenceIdentifier, $event->form);
     }
 }

--- a/Classes/Utility/UniqueFieldHandler.php
+++ b/Classes/Utility/UniqueFieldHandler.php
@@ -187,8 +187,7 @@ class UniqueFieldHandler
      */
     protected function setExistingFieldStateBeforeSave(string $formPersistenceIdentifier): void
     {
-        $formSettings = $this->getFormSettings();
-        $formDefinitionBeforeSave = $this->formPersistenceManager->load($formPersistenceIdentifier, $formSettings, []);
+        $formDefinitionBeforeSave = $this->formPersistenceManager->load($formPersistenceIdentifier);
         $this->existingFieldStateBeforeSave = $formDefinitionBeforeSave['renderingOptions']['fieldState'] ?? [];
     }
 }

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -8,7 +8,7 @@ return [
         'position' => ['after' => 'web_FormFormbuilder'],
         'access' => 'user',
         'workspaces' => '*',
-        'icon'   => 'EXT:form_to_database/Resources/Public/Icons/Extension.svg',
+        'icon'   => 'EXT:form_to_database/Resources/Public/Icons/ModuleFormToDatabase.svg',
         'path' => '/module/web/FormToDatabaseFormresults',
         'labels' => 'LLL:EXT:form_to_database/Resources/Private/Language/locallang_mod.xlf',
         'extensionName' => 'FormToDatabase',

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -10,6 +10,10 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:form_to_database/Resources/Public/Icons/Extension.svg',
     ],
+    'module-formtodatabase' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:form_to_database/Resources/Public/Icons/ModuleFormToDatabase.svg',
+    ],
     'actions-print' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:form_to_database/Resources/Public/Icons/action-print.svg',

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'dependencies' => [
+        'backend',
+    ],
+    'imports' => [
+        '@liquidlight/form-to-database/' => 'EXT:form_to_database/Resources/Public/JavaScript/',
+    ],
+];

--- a/Resources/Private/Partials/FormResults/Show/ItemListSelect.html
+++ b/Resources/Private/Partials/FormResults/Show/ItemListSelect.html
@@ -3,66 +3,94 @@
 	  xmlns:ftdb="http://typo3.org/ns/LiquidLight/FormToDatabase/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
 <!--
-	Content of the column selection modal. Rendered into a <template> and
-	opened via @liquidlight/form-to-database/column-selector.js using the
-	TYPO3 Modal API (Bootstrap modals were removed in TYPO3 v14).
+	Content of the column selection modal, mirroring the markup of the core
+	record list column selector (EXT:backend ColumnSelector.fluid.html).
+	Rendered into a <template> and opened via
+	@liquidlight/form-to-database/column-selector.js using the TYPO3 Modal API
+	(Bootstrap modals were removed in TYPO3 v14).
 -->
 <template id="itemListSelect">
 	<f:form action="updateItemListSelect">
-		<table class="table table-striped table-hover">
-			<thead>
-			<tr>
-				<th>
-					<f:translate
-							key="LLL:EXT:form/Resources/Private/Language/Database.xlf:formEditor.elements.FormElement.editor.label.label"/>
-				</th>
-				<th>
-					<f:translate
-							key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.table.elementtype"/>
-				</th>
-				<th>
-					<f:translate
-							key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.table.identifier"/>
-				</th>
-				<th>
-					<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:enable"/>
-				</th>
-			</tr>
-			</thead>
-			<tbody>
+
+		<div class="sticky-form-actions">
+			<label for="ftd-columns-filter-input" class="visually-hidden">
+				<f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang_column_selector.xlf:columnsFilter"/>
+			</label>
+			<input
+				type="search"
+				autocomplete="off"
+				id="ftd-columns-filter-input"
+				name="columns-filter"
+				class="form-control"
+				value=""
+				placeholder="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enterSearchString')}"
+			>
+			<div class="btn-group t3js-column-selector-actions">
+				<button type="button" class="btn btn-default disabled" data-action="select-all">
+					<core:icon identifier="actions-check-square"/> <f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.checkAll"/>
+				</button>
+				<button type="button" class="btn btn-default disabled" data-action="select-none">
+					<core:icon identifier="actions-square"/> <f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.uncheckAll"/>
+				</button>
+				<button type="button" class="btn btn-default" data-action="select-toggle">
+					<core:icon identifier="actions-document-select"/> <f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.toggleSelection"/>
+				</button>
+			</div>
+		</div>
+
+		<div class="row">
 			<f:groupedFor groupBy="renderingOptions.deleted" groupKey="deleted" each="{formRenderables}" as="renderables">
 				<f:if condition="{deleted} == 1">
-					<tr>
-						<th colspan="4">
+					<div class="col-12 mt-3">
+						<strong>
 							<f:translate
 									key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.deleted_fields"/>
-						</th>
-					</tr>
+						</strong>
+					</div>
 				</f:if>
 				<f:for each="{renderables}" as="renderable">
 					<f:if condition="{fieldsWithData.{renderable.identifier}}">
-						<tr>
-							<th>{renderable.label}</th>
-							<td>{renderable.type}</td>
-							<td>{renderable.identifier}</td>
-							<td>
-								<f:form.checkbox
-										checked="{f:if(condition:'{renderable.renderingOptions.listView}', then:'checked')}"
-										name="field[{renderable.identifier}]" value="1"></f:form.checkbox>
-							</td>
-						</tr>
+						<div class="col-6 t3js-column-selector-container">
+							<div class="mt-2 form-check form-check-type-icon-toggle">
+								<input
+									type="checkbox"
+									id="ftd-select-column-{renderable.identifier}"
+									name="field[{renderable.identifier}]"
+									class="form-check-input t3js-column-selector"
+									value="1"
+									{f:if(condition:'{renderable.renderingOptions.listView}', then:' checked')}
+								/>
+								<label class="form-check-label" for="ftd-select-column-{renderable.identifier}">
+									<span class="form-check-label-icon">
+										<span class="form-check-label-icon-checked">
+											<core:icon identifier="actions-check" size="small" alternativeMarkupIdentifier="inline"/>
+										</span>
+										<span class="form-check-label-icon-unchecked">
+											<core:icon identifier="miscellaneous-placeholder" size="small" alternativeMarkupIdentifier="inline"/>
+										</span>
+									</span>
+									<f:if condition="{renderable.label}">
+										<span>{renderable.label}</span>
+									</f:if>
+									<span class="text-variant">[{renderable.identifier}]</span>
+								</label>
+							</div>
+						</div>
 					</f:if>
 				</f:for>
 			</f:groupedFor>
-			</tbody>
-		</table>
+		</div>
+
 		<f:if condition="{fieldsWithNoData}">
-			<f:translate
-					key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.fields_no_data"/><br/>
-			<f:for each="{fieldsWithNoData}" key="field" as="dataExists" iteration="iterator">
-				{field}<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
-			</f:for>
+			<div class="mt-3 text-body-secondary">
+				<f:translate
+						key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.fields_no_data"/><br/>
+				<f:for each="{fieldsWithNoData}" key="field" as="dataExists" iteration="iterator">
+					{field}<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
+				</f:for>
+			</div>
 		</f:if>
+
 		<f:form.hidden name="formPersistenceIdentifier" value="{formPersistenceIdentifier}"/>
 	</f:form>
 </template>

--- a/Resources/Private/Partials/FormResults/Show/ItemListSelect.html
+++ b/Resources/Private/Partials/FormResults/Show/ItemListSelect.html
@@ -2,88 +2,69 @@
 	  xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
 	  xmlns:ftdb="http://typo3.org/ns/LiquidLight/FormToDatabase/ViewHelpers"
 	  data-namespace-typo3-fluid="true">
-<f:form action="updateItemListSelect">
-	<div class="t3js-modal modal fade modal-severity-notice modal-style-default modal-size-medium"
-		 id="itemListSelect" tabindex="-1" role="dialog" aria-hidden="true">
-		<div class="modal-dialog" role="document">
-			<div class="t3js-modal-content modal-content">
-				<div class="modal-header">
-					<button type="submit" class="btn btn-default btn-sm t3js-modal-close" style="float: right;"
-							data-bs-dismiss="modal" aria-label="Close">
-						<core:icon identifier="actions-close"/>
-						<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:close"/>
-					</button>
-					<f:form.button class="btn btn-default btn-sm t3js-modal-close"
-								   style="float: right;margin-right: 5px;">
-						<core:icon identifier="actions-document-save-close"/>
-						<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:saveAndClose"/>
-					</f:form.button>
-					<h4 class="t3js-modal-title modal-title">
-						<f:translate
-								key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.header"/>
-					</h4>
-				</div>
-				<div class="t3js-modal-body modal-body">
-					<table class="table table-striped table-hover">
-						<thead>
+<!--
+	Content of the column selection modal. Rendered into a <template> and
+	opened via @liquidlight/form-to-database/column-selector.js using the
+	TYPO3 Modal API (Bootstrap modals were removed in TYPO3 v14).
+-->
+<template id="itemListSelect">
+	<f:form action="updateItemListSelect">
+		<table class="table table-striped table-hover">
+			<thead>
+			<tr>
+				<th>
+					<f:translate
+							key="LLL:EXT:form/Resources/Private/Language/Database.xlf:formEditor.elements.FormElement.editor.label.label"/>
+				</th>
+				<th>
+					<f:translate
+							key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.table.elementtype"/>
+				</th>
+				<th>
+					<f:translate
+							key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.table.identifier"/>
+				</th>
+				<th>
+					<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:enable"/>
+				</th>
+			</tr>
+			</thead>
+			<tbody>
+			<f:groupedFor groupBy="renderingOptions.deleted" groupKey="deleted" each="{formRenderables}" as="renderables">
+				<f:if condition="{deleted} == 1">
+					<tr>
+						<th colspan="4">
+							<f:translate
+									key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.deleted_fields"/>
+						</th>
+					</tr>
+				</f:if>
+				<f:for each="{renderables}" as="renderable">
+					<f:if condition="{fieldsWithData.{renderable.identifier}}">
 						<tr>
-							<th>
-								<f:translate
-										key="LLL:EXT:form/Resources/Private/Language/Database.xlf:formEditor.elements.FormElement.editor.label.label"/>
-							</th>
-							<th>
-								<f:translate
-										key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.table.elementtype"/>
-							</th>
-							<th>
-								<f:translate
-										key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.table.identifier"/>
-							</th>
-							<th>
-								<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:enable"/>
-							</th>
+							<th>{renderable.label}</th>
+							<td>{renderable.type}</td>
+							<td>{renderable.identifier}</td>
+							<td>
+								<f:form.checkbox
+										checked="{f:if(condition:'{renderable.renderingOptions.listView}', then:'checked')}"
+										name="field[{renderable.identifier}]" value="1"></f:form.checkbox>
+							</td>
 						</tr>
-						</thead>
-						<tbody>
-						<f:groupedFor groupBy="renderingOptions.deleted" groupKey="deleted" each="{formRenderables}" as="renderables">
-							<f:if condition="{deleted} == 1">
-								<tr>
-									<th colspan="4">
-										<f:translate
-												key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.deleted_fields"/>
-									</th>
-								</tr>
-							</f:if>
-							<f:for each="{renderables}" as="renderable">
-								<f:if condition="{fieldsWithData.{renderable.identifier}}">
-									<tr>
-										<th>{renderable.label}</th>
-										<td>{renderable.type}</td>
-										<td>{renderable.identifier}</td>
-										<td>
-											<f:form.checkbox
-													checked="{f:if(condition:'{renderable.renderingOptions.listView}', then:'checked')}"
-													name="field[{renderable.identifier}]" value="1"></f:form.checkbox>
-										</td>
-									</tr>
-								</f:if>
-							</f:for>
-						</f:groupedFor>
-						</tbody>
-					</table>
-					<f:if condition="{fieldsWithNoData}">
-						<f:translate
-								key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.fields_no_data"/><br/>
-						<f:for each="{fieldsWithNoData}" key="field" as="dataExists" iteration="iterator">
-							{field}<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
-						</f:for>
 					</f:if>
-				</div>
-				<f:form.hidden name="formPersistenceIdentifier" value="{formPersistenceIdentifier}"/>
-				<br/>
-			</div>
-		</div>
-	</div>
-</f:form>
+				</f:for>
+			</f:groupedFor>
+			</tbody>
+		</table>
+		<f:if condition="{fieldsWithNoData}">
+			<f:translate
+					key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.fields_no_data"/><br/>
+			<f:for each="{fieldsWithNoData}" key="field" as="dataExists" iteration="iterator">
+				{field}<f:if condition="{iterator.isLast}"><f:else>,</f:else></f:if>
+			</f:for>
+		</f:if>
+		<f:form.hidden name="formPersistenceIdentifier" value="{formPersistenceIdentifier}"/>
+	</f:form>
+</template>
 
 </html>

--- a/Resources/Private/Partials/FormResults/Show/Results.html
+++ b/Resources/Private/Partials/FormResults/Show/Results.html
@@ -47,7 +47,7 @@
 							<a href="#" class="btn btn-sm btn-default t3js-form-to-database-column-selector"
 							   data-modal-title="{f:translate(key: 'LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.header')}"
 							   data-button-close-text="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:close')}"
-							   data-button-ok-text="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:saveAndClose')}">
+							   data-button-ok-text="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:ok')}">
 								<core:icon identifier="actions-cog" size="small"/>
 								<f:translate
 										key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.buttons.column_settings"/>

--- a/Resources/Private/Partials/FormResults/Show/Results.html
+++ b/Resources/Private/Partials/FormResults/Show/Results.html
@@ -44,8 +44,10 @@
 					</f:for>
 					<th class="col-control nowrap">
 						<div class="btn-group" role="group">
-							<a href="#" class="btn btn-sm btn-default" data-bs-toggle="modal"
-							   data-bs-target="#itemListSelect">
+							<a href="#" class="btn btn-sm btn-default t3js-form-to-database-column-selector"
+							   data-modal-title="{f:translate(key: 'LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.itemListSelect.header')}"
+							   data-button-close-text="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:close')}"
+							   data-button-ok-text="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:saveAndClose')}">
 								<core:icon identifier="actions-cog" size="small"/>
 								<f:translate
 										key="LLL:EXT:form_to_database/Resources/Private/Language/locallang_be.xlf:show.buttons.column_settings"/>

--- a/Resources/Public/Icons/ModuleFormToDatabase.svg
+++ b/Resources/Public/Icons/ModuleFormToDatabase.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<path fill="var(--icon-color-accent, #ff8700)" d="M24 48h-8c-2.21 0-4-1.79-4-4V16c0-2.21 1.79-4 4-4h32c2.21 0 4 1.79 4 4v12c0 1.1-.9 2-2 2s-2-.9-2-2V16H16v28h8c1.1 0 2 .9 2 2s-.9 2-2 2Z"/>
+	<g fill="currentColor" opacity=".4">
+		<rect width="24" height="4" x="20" y="22" rx="2" ry="2"/>
+		<rect width="8" height="4" x="20" y="30" rx="2" ry="2"/>
+	</g>
+	<ellipse cx="42" cy="33" rx="10" ry="4" fill="currentColor"/>
+	<path fill="currentColor" opacity=".4" d="M32 37a10 4 0 0 0 20 0v5a10 4 0 0 1-20 0v-5Z"/>
+	<path fill="currentColor" d="M32 42a10 4 0 0 0 20 0v5a10 4 0 0 1-20 0v-5Z"/>
+</svg>

--- a/Resources/Public/JavaScript/column-selector.js
+++ b/Resources/Public/JavaScript/column-selector.js
@@ -1,0 +1,45 @@
+/**
+ * Module: @liquidlight/form-to-database/column-selector.js
+ *
+ * Opens the column selection of the form results module in a TYPO3 modal.
+ * Replaces the former Bootstrap modal markup (data-bs-toggle/data-bs-target),
+ * which is no longer supported since TYPO3 v14 (Breaking #107443).
+ */
+import Modal from '@typo3/backend/modal.js';
+import Severity from '@typo3/backend/severity.js';
+import RegularEvent from '@typo3/core/event/regular-event.js';
+
+class ColumnSelector {
+  constructor() {
+    new RegularEvent('click', (event, target) => {
+      event.preventDefault();
+      const template = document.getElementById('itemListSelect');
+      if (template === null) {
+        return;
+      }
+      const content = template.content.firstElementChild.cloneNode(true);
+      Modal.advanced({
+        title: target.dataset.modalTitle || 'Columns',
+        content: content,
+        severity: Severity.notice,
+        size: Modal.sizes.medium,
+        buttons: [
+          {
+            text: target.dataset.buttonCloseText || 'Close',
+            active: true,
+            btnClass: 'btn-default',
+            trigger: (e, modal) => modal.hideModal(),
+          },
+          {
+            text: target.dataset.buttonOkText || 'Save',
+            btnClass: 'btn-primary',
+            icon: 'actions-document-save-close',
+            trigger: (e, modal) => modal.querySelector('form')?.requestSubmit(),
+          },
+        ],
+      });
+    }).delegateTo(document, '.t3js-form-to-database-column-selector');
+  }
+}
+
+export default new ColumnSelector();

--- a/Resources/Public/JavaScript/column-selector.js
+++ b/Resources/Public/JavaScript/column-selector.js
@@ -1,13 +1,22 @@
 /**
  * Module: @liquidlight/form-to-database/column-selector.js
  *
- * Opens the column selection of the form results module in a TYPO3 modal.
- * Replaces the former Bootstrap modal markup (data-bs-toggle/data-bs-target),
- * which is no longer supported since TYPO3 v14 (Breaking #107443).
+ * Opens the column selection of the form results module in a TYPO3 modal,
+ * replicating the look and behavior of the core record list column selector
+ * (@typo3/backend/column-selector-button.js). Replaces the former Bootstrap
+ * modal markup, which is no longer supported since TYPO3 v14
+ * (Breaking #107443).
  */
 import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 import RegularEvent from '@typo3/core/event/regular-event.js';
+
+const Selectors = {
+  columnsSelector: '.t3js-column-selector',
+  columnsContainerSelector: '.t3js-column-selector-container',
+  columnsFilterSelector: 'input[name="columns-filter"]',
+  columnsSelectorActionsSelector: '.t3js-column-selector-actions',
+};
 
 class ColumnSelector {
   constructor() {
@@ -18,8 +27,8 @@ class ColumnSelector {
         return;
       }
       const content = template.content.firstElementChild.cloneNode(true);
-      Modal.advanced({
-        title: target.dataset.modalTitle || 'Columns',
+      const modal = Modal.advanced({
+        title: target.dataset.modalTitle || 'Show columns',
         content: content,
         severity: Severity.notice,
         size: Modal.sizes.medium,
@@ -28,17 +37,132 @@ class ColumnSelector {
             text: target.dataset.buttonCloseText || 'Close',
             active: true,
             btnClass: 'btn-default',
-            trigger: (e, modal) => modal.hideModal(),
+            name: 'cancel',
+            trigger: (e, currentModal) => currentModal.hideModal(),
           },
           {
-            text: target.dataset.buttonOkText || 'Save',
+            text: target.dataset.buttonOkText || 'OK',
             btnClass: 'btn-primary',
-            icon: 'actions-document-save-close',
-            trigger: (e, modal) => modal.querySelector('form')?.requestSubmit(),
+            name: 'update',
+            trigger: (e, currentModal) => currentModal.querySelector('form')?.requestSubmit(),
           },
         ],
+        callback: (currentModal) => this.initializeContent(currentModal),
       });
     }).delegateTo(document, '.t3js-form-to-database-column-selector');
+  }
+
+  static isColumnHidden(column) {
+    return column.closest(Selectors.columnsContainerSelector)?.classList.contains('hidden');
+  }
+
+  static filterColumns(filterField, columns) {
+    columns.forEach((column) => {
+      const container = column.closest(Selectors.columnsContainerSelector);
+      if (!column.disabled && container !== null) {
+        const label = container.querySelector('.form-check-label')?.textContent;
+        if (label && label.length) {
+          container.classList.toggle(
+            'hidden',
+            filterField.value !== '' && !RegExp(filterField.value, 'i').test(
+              label.trim().replace(/\[\]/g, '').replace(/\s+/g, ' ')
+            )
+          );
+        }
+      }
+    });
+  }
+
+  static toggleSelectorActions(columns, selectAll, selectNone, initialize = false) {
+    selectAll.classList.add('disabled');
+    for (let i = 0; i < columns.length; i++) {
+      if (!columns[i].disabled && !columns[i].checked && (initialize || !ColumnSelector.isColumnHidden(columns[i]))) {
+        selectAll.classList.remove('disabled');
+        break;
+      }
+    }
+    selectNone.classList.add('disabled');
+    for (let i = 0; i < columns.length; i++) {
+      if (!columns[i].disabled && columns[i].checked && (initialize || !ColumnSelector.isColumnHidden(columns[i]))) {
+        selectNone.classList.remove('disabled');
+        break;
+      }
+    }
+  }
+
+  initializeContent(modal) {
+    const form = modal.querySelector('form');
+    if (form === null) {
+      return;
+    }
+    const columns = modal.querySelectorAll(Selectors.columnsSelector);
+    const columnsFilter = modal.querySelector(Selectors.columnsFilterSelector);
+    const columnsSelectorActions = modal.querySelector(Selectors.columnsSelectorActionsSelector);
+    if (!columns.length || columnsFilter === null || columnsSelectorActions === null) {
+      return;
+    }
+    const selectAll = columnsSelectorActions.querySelector('button[data-action="select-all"]');
+    const selectNone = columnsSelectorActions.querySelector('button[data-action="select-none"]');
+    if (selectAll === null || selectNone === null) {
+      return;
+    }
+
+    ColumnSelector.toggleSelectorActions(columns, selectAll, selectNone, true);
+    columns.forEach((column) => {
+      column.addEventListener('change', () => {
+        ColumnSelector.toggleSelectorActions(columns, selectAll, selectNone);
+      });
+    });
+
+    columnsFilter.addEventListener('keydown', (e) => {
+      // Prevent implicit form submission from the search field,
+      // clear it on Escape without closing the modal
+      if (e.code === 'Enter') {
+        e.preventDefault();
+      }
+      if (e.code === 'Escape') {
+        e.stopImmediatePropagation();
+        e.target.value = '';
+      }
+    });
+    columnsFilter.addEventListener('keyup', (e) => {
+      ColumnSelector.filterColumns(e.target, columns);
+      ColumnSelector.toggleSelectorActions(columns, selectAll, selectNone);
+    });
+    columnsFilter.addEventListener('search', (e) => {
+      ColumnSelector.filterColumns(e.target, columns);
+      ColumnSelector.toggleSelectorActions(columns, selectAll, selectNone);
+    });
+
+    columnsSelectorActions.querySelectorAll('button[data-action]').forEach((button) => {
+      button.addEventListener('click', (e) => {
+        e.preventDefault();
+        switch (button.dataset.action) {
+          case 'select-toggle':
+            columns.forEach((column) => {
+              if (!column.disabled && !ColumnSelector.isColumnHidden(column)) {
+                column.checked = !column.checked;
+              }
+            });
+            break;
+          case 'select-all':
+            columns.forEach((column) => {
+              if (!column.disabled && !ColumnSelector.isColumnHidden(column)) {
+                column.checked = true;
+              }
+            });
+            break;
+          case 'select-none':
+            columns.forEach((column) => {
+              if (!column.disabled && !ColumnSelector.isColumnHidden(column)) {
+                column.checked = false;
+              }
+            });
+            break;
+        }
+        ColumnSelector.toggleSelectorActions(columns, selectAll, selectNone);
+      });
+    });
   }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "liquidlight/typo3-form-to-database",
   "description": "Extends the TYPO3 form with a database finisher, to save every form-result in the database.",
-  "version": "5.3.1",
+  "version": "6.0.0",
   "type": "typo3-cms-extension",
   "keywords": [
     "TYPO3",
@@ -47,12 +47,12 @@
   "require": {
     "php": "^8.2 || ^8.3 || ^8.4",
     "ext-json": "*",
-    "typo3/cms-backend": "^13.4.20",
-    "typo3/cms-core": "^13.4.20",
-    "typo3/cms-extbase": "^13.4.20",
-    "typo3/cms-fluid": "^13.4.20",
-    "typo3/cms-form": "^13.4.20",
-    "typo3/cms-frontend": "^13.4.20"
+    "typo3/cms-backend": "^14.3",
+    "typo3/cms-core": "^14.3",
+    "typo3/cms-extbase": "^14.3",
+    "typo3/cms-fluid": "^14.3",
+    "typo3/cms-form": "^14.3",
+    "typo3/cms-frontend": "^14.3"
   },
   "suggest": {
     "mpdf/mpdf": "Allows downloading form results as a PDF"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,8 +17,8 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'frontend',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.4.20-13.4.99',
-            'form' => '13.4.20-13.4.99',
+            'typo3' => '14.3.0-14.99.99',
+            'form' => '14.3.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],
@@ -32,5 +32,5 @@ $EM_CONF[$_EXTKEY] = [
 	'author' => 'Liquid Light',
 	'author_email' => 'info@liquidlight.co.uk',
 	'author_company' => 'Liquid Light Ltd',
-    'version' => '5.3.1'
+    'version' => '6.0.0'
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,13 +7,13 @@
  */
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use LiquidLight\FormToDatabase\Hooks\FormHooks;
 
 defined('TYPO3') or die();
 
 (static function (): void {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeFormSave'][] = FormHooks::class;
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['beforeFormDelete'][] = FormHooks::class;
+    // The former SC_OPTIONS ext/form hooks (beforeFormSave, beforeFormDelete) were
+    // removed in TYPO3 v14; FormHooks now listens to the PSR-14 events
+    // BeforeFormIsSavedEvent / BeforeFormIsDeletedEvent (see #[AsEventListener]).
 
     ExtensionManagementUtility::addTypoScriptSetup('
         plugin.tx_form.settings.yamlConfigurations {


### PR DESCRIPTION
## Why

  TYPO3 v14.3 / EXT:form v14 removed or changed several APIs this extension relies on.
  This PR ports the extension to TYPO3 v14 (`typo3/cms-* ^14.3`, version 6.0.0 — breaking,
  since v13 support is dropped).

  ## Breaking changes handled

  - **`SC_OPTIONS ext/form` hooks removed** — the `beforeFormSave` / `beforeFormDelete`
    hooks no longer exist in v14. `FormHooks` now listens to the PSR-14 events
    `BeforeFormIsSavedEvent` (mutating `$event->form`, replacing the old return-value
    contract) and `BeforeFormIsDeletedEvent`, registered via `#[AsEventListener]`.
    The `ext_localconf.php` hook registration is dropped.
  - **`FormPersistenceManager` API changes**
    - `listForms()` now requires a `SearchCriteria` DTO and returns `FormMetadata`
      objects — converted back to the array shape used by the templates and the
      enrichment methods (`numberOfResults`, `maxCrDate`, …).
    - `load()` lost the `$formSettings` / `$typoScriptSettings` array parameters
      (the third parameter is now `?ServerRequestInterface`) — all call sites
      simplified to `load($persistenceIdentifier)`.
    - `getAccessibleFormStorageFolders()` moved to the new `FileMountStorageAdapter`
      (same `Folder[]` return) — now injected into the controller.
  - **`FormManagerController::getAvailableFormDefinitions()` signature changed**
    (`SearchCriteria` DTO) — the override and its call sites are adapted; the previous
    `$searchTerm`/`$orderField`/`$orderDirection` parameters were unused.
  - **`TYPO3\CMS\Form\Enum\SortDirection` removed** — order arguments are `?string`,
    mirroring the core `FormManagerController`.

  ## Also included
  
  - New backend module icon `ModuleFormToDatabase.svg` in the TYPO3 core icon style
    (64×64, `currentColor` motif, `--icon-color-accent`, `.4`-opacity tertiary shapes),
    wired into `Modules.php` and registered as `module-formtodatabase`.

  ## Verification

  - Module `indexAction` dispatched through the full extbase/backend stack on
    TYPO3 v14.3: HTTP 200 with complete module markup.
  - Both PSR-14 listeners bound in the compiled container; the `FormToDatabase`
    finisher definition loads through the form framework YAML chain.
  - All files pass `php -l`; extension installs and activates via Composer
    (path repository).

  ## Notes for reviewers

  - Version constraint raised to `^14.3` — a v13-compatible release should be
    maintained on a separate branch if needed, since the hook→event migration
    cannot be made cross-version compatible without a compatibility layer.